### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     Rcpp (>= 1.0.8.3),
     RcppParallel,
     rstantools,
-    rstan (>= 2.21.3),
+    rstan (>= 2.26.0),
     scales,
     stats,
     utils
@@ -36,15 +36,15 @@ Suggests:
     knitr,
     rmarkdown,
     roxygen2,
-    StanHeaders (>= 2.21.0),
+    StanHeaders (>= 2.26.0),
     testthat (>= 3.0.0)
 LinkingTo: 
     BH (>= 1.78.0-0),
     Rcpp (>= 1.0.8.3),
     RcppEigen (>= 0.3.3.9.1),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.21.3),
-    StanHeaders (>= 2.21.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 VignetteBuilder: 
     knitr
 Biarch: true


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
